### PR TITLE
Fix race condition by synchronizing access/modification of connection @state

### DIFF
--- a/lib/ione/io/connection.rb
+++ b/lib/ione/io/connection.rb
@@ -14,7 +14,6 @@ module Ione
         @unblocker = unblocker
         @clock = clock
         @socket_impl = socket_impl
-        @lock = Mutex.new
         @write_buffer = ByteBuffer.new
         @connected_promise = Promise.new
         on_closed(&method(:cleanup_on_close))

--- a/lib/ione/io/server_connection.rb
+++ b/lib/ione/io/server_connection.rb
@@ -8,7 +8,6 @@ module Ione
         super(host, port)
         @io = socket
         @unblocker = unblocker
-        @lock = Mutex.new
         @write_buffer = ByteBuffer.new
         @state = :connected
       end


### PR DESCRIPTION
(Per @iconara's request on https://github.com/iconara/ione/pull/8)

Ensure @state check and set operations are done in critical section, to avoid this method from being executed multiple times in a multi-threaded race-condition scenario.

I noticed that the `@lock` attribute was being referenced in `BaseConnection` but defined in its subclasses.  I pulled its creation/initialization into the initializer of `BaseConnection`.
