### PR TITLE
prevent reactor from crashing when timers cancelled

### DIFF
--- a/lib/ione/io/io_reactor.rb
+++ b/lib/ione/io/io_reactor.rb
@@ -356,7 +356,7 @@ module Ione
       def cancel_timers
         @timers.each do |pair|
           if pair[1]
-            pair[1].fail(CancelledError.new)
+            pair[1].fail(CancelledError.new) rescue nil
             pair[1] = nil
           end
         end
@@ -395,7 +395,7 @@ module Ione
         timers = @timers
         timers.each do |pair|
           if pair[1] && pair[0] <= @clock.now
-            pair[1].fulfill
+            pair[1].fulfill rescue nil
             pair[1] = nil
           end
         end


### PR DESCRIPTION
I'm seeing reactor crashes due to timer futures raising an error because they were resolved. Not sure how exactly to reproduce it since that would require more digging.
