### PR TITLE
Restartable reactor

### DIFF
--- a/lib/ione/io/io_reactor.rb
+++ b/lib/ione/io/io_reactor.rb
@@ -85,14 +85,12 @@ module Ione
       #
       # @param options [Hash] only used to inject behaviour during tests
       def initialize(options={})
+        @options = options
         @clock = options[:clock] || Time
-        @unblocker = Unblocker.new
-        @io_loop = IoLoopBody.new(options)
-        @io_loop.add_socket(@unblocker)
-        @scheduler = Scheduler.new
         @state = :pending
-        @started_promise = Promise.new
-        @stopped_promise = Promise.new
+        @error_listeners = []
+        @io_loop = IoLoopBody.new(@options)
+        @scheduler = Scheduler.new
         @lock = Mutex.new
       end
 
@@ -104,7 +102,16 @@ module Ione
       #
       # @yield [error] the error that cause the reactor to stop
       def on_error(&listener)
-        @stopped_promise.future.on_failure(&listener)
+        @lock.lock
+        begin
+          @error_listeners = @error_listeners.dup
+          @error_listeners << listener
+        ensure
+          @lock.unlock
+        end
+        if @state == :running || @state == :crashed
+          @stopped_promise.future.on_failure(&listener)
+        end
       end
 
       # Returns true as long as the reactor is running. It will be true even
@@ -123,9 +130,20 @@ module Ione
       # @return [Ione::Future] a future that will resolve to the reactor itself
       def start
         @lock.synchronize do
-          raise ReactorError, 'Cannot start a stopped IO reactor' if @state == :stopped
-          return @started_promise.future if @state == :running
-          @state = :running
+          if @state == :running
+            return @started_promise.future
+          elsif @state == :stopping
+            return @stopped_promise.future.flat_map { start }.fallback { start }
+          else
+            @state = :running
+          end
+        end
+        @unblocker = Unblocker.new
+        @io_loop.add_socket(@unblocker)
+        @started_promise = Promise.new
+        @stopped_promise = Promise.new
+        @error_listeners.each do |listener|
+          @stopped_promise.future.on_failure(&listener)
         end
         Thread.start do
           @started_promise.fulfill(self)
@@ -135,13 +153,18 @@ module Ione
               @scheduler.tick
             end
           ensure
-            @io_loop.close_sockets
-            @scheduler.cancel_timers
-            @state = :stopped
-            if $!
-              @stopped_promise.fail($!)
-            else
-              @stopped_promise.fulfill(self)
+            begin
+              @io_loop.close_sockets
+              @scheduler.cancel_timers
+              @unblocker = nil
+            ensure
+              if $!
+                @state = :crashed
+                @stopped_promise.fail($!)
+              else
+                @state = :stopped
+                @stopped_promise.fulfill(self)
+              end
             end
           end
         end
@@ -156,9 +179,16 @@ module Ione
       #
       # @return [Ione::Future] a future that will resolve to the reactor itself
       def stop
-        @unblocker.unblock
-        @state = :stopping
-        @stopped_promise.future
+        @lock.synchronize do
+          if @state == :pending
+            Future.resolved(self)
+          elsif @state != :stopped && @state != :crashed
+            @state = :stopping
+            @stopped_promise.future
+          else
+            @stopped_promise.future
+          end
+        end
       end
 
       # Opens a connection to the specified host and port.
@@ -196,7 +226,7 @@ module Ione
         connection = Connection.new(host, port, timeout, @unblocker, @clock)
         f = connection.connect
         @io_loop.add_socket(connection)
-        @unblocker.unblock
+        @unblocker.unblock if running?
         if ssl
           f = f.flat_map do
             ssl_context = ssl == true ? nil : ssl
@@ -281,7 +311,7 @@ module Ione
         end
         f = server.bind
         @io_loop.add_socket(server)
-        @unblocker.unblock
+        @unblocker.unblock if running?
         f = f.map(&block) if block_given?
         f
       end
@@ -312,7 +342,7 @@ module Ione
       end
 
       def to_s
-        @io_loop.to_s
+        %(#<#{self.class.name} @state=#{@state.inspect}>)
       end
     end
 
@@ -446,6 +476,7 @@ module Ione
             # the socket had most likely already closed due to an error
           end
         end
+        @sockets = []
       end
 
       def tick
@@ -524,6 +555,7 @@ module Ione
         timers.each do |timer|
           timer.fail(CancelledError.new)
         end
+        nil
       end
 
       def tick

--- a/spec/ione/io/io_reactor_spec.rb
+++ b/spec/ione/io/io_reactor_spec.rb
@@ -84,9 +84,12 @@ module Ione
             barrier.push(nil)
             stopped_future.value
             restarted_future.value
-            sequence.should == [:stopped, :restarted]
-            reactor.stop
-            barrier.push(nil) while reactor.running?
+            begin
+              sequence.should == [:stopped, :restarted]
+            ensure
+              reactor.stop
+              barrier.push(nil) while reactor.running?
+            end
           end
 
           it 'restarts the reactor even when restarted before a failed stop' do
@@ -107,9 +110,12 @@ module Ione
             barrier.push(:fail)
             stopped_future.value rescue nil
             restarted_future.value
-            sequence.should == [:crashed, :restarted]
-            reactor.stop
-            barrier.push(nil) while reactor.running?
+            begin
+              sequence.should == [:crashed, :restarted]
+            ensure
+              reactor.stop
+              barrier.push(nil) while reactor.running?
+            end
           end
         end
 
@@ -140,9 +146,12 @@ module Ione
             reactor.start.value
             reactor.start.value
             reactor.start.value
-            lock.synchronize { calls }.should == 1
-            reactor.stop
-            barrier.push(nil) while reactor.running?
+            begin
+              lock.synchronize { calls }.should == 1
+            ensure
+              reactor.stop
+              barrier.push(nil) while reactor.running?
+            end
           end
         end
       end

--- a/spec/ione/io/io_reactor_spec.rb
+++ b/spec/ione/io/io_reactor_spec.rb
@@ -85,7 +85,8 @@ module Ione
             stopped_future.value
             restarted_future.value
             sequence.should == [:stopped, :restarted]
-            barrier.push(nil)
+            reactor.stop
+            barrier.push(nil) while reactor.running?
           end
 
           it 'restarts the reactor even when restarted before a failed stop' do
@@ -107,7 +108,8 @@ module Ione
             stopped_future.value rescue nil
             restarted_future.value
             sequence.should == [:crashed, :restarted]
-            barrier.push(nil)
+            reactor.stop
+            barrier.push(nil) while reactor.running?
           end
         end
 

--- a/spec/ione/io/io_reactor_spec.rb
+++ b/spec/ione/io/io_reactor_spec.rb
@@ -137,11 +137,10 @@ module Ione
           it 'is not started again' do
             calls = 0
             lock = Mutex.new
+            ticks = Queue.new
             barrier = Queue.new
             selector.handler do
-              lock.synchronize do
-                calls += 1
-              end
+              ticks.push(:tick)
               barrier.pop
               [[], [], []]
             end
@@ -149,7 +148,8 @@ module Ione
             reactor.start.value
             reactor.start.value
             begin
-              lock.synchronize { calls }.should == 1
+              ticks.pop.should_not be_nil
+              ticks.size.should be_zero
             ensure
               reactor.stop
               barrier.push(nil) while reactor.running?

--- a/spec/ione/io/io_reactor_spec.rb
+++ b/spec/ione/io/io_reactor_spec.rb
@@ -140,8 +140,9 @@ module Ione
             reactor.start.value
             reactor.start.value
             reactor.start.value
-            calls.should == 1
-            barrier.push(nil)
+            lock.synchronize { calls }.should == 1
+            reactor.stop
+            barrier.push(nil) while reactor.running?
           end
         end
       end

--- a/spec/ione/io/io_reactor_spec.rb
+++ b/spec/ione/io/io_reactor_spec.rb
@@ -104,14 +104,16 @@ module Ione
             reactor.start.value
             stopped_future = reactor.stop
             restarted_future = reactor.start
-            sequence = []
-            stopped_future.on_failure { sequence << :crashed }
-            restarted_future.on_complete { sequence << :restarted }
+            crashed = false
+            restarted = false
+            stopped_future.on_failure { crashed = true }
+            restarted_future.on_complete { restarted = true }
             barrier.push(:fail)
             stopped_future.value rescue nil
             restarted_future.value
             begin
-              sequence.should == [:crashed, :restarted]
+              crashed.should be_true
+              restarted.should be_true
             ensure
               reactor.stop
               barrier.push(nil) while reactor.running?


### PR DESCRIPTION
Currently `IoReactor` cannot be restarted, but that's mostly because I've been lazy. This tries to add tests that make sure things are properly clean up before a restart and implementation that isn't too complicated (but there's a few crazy things like calling the error listeners).