### PR TITLE
Select timer timeout

### DIFF
--- a/examples/motd_server/spec/ione/motd_server_spec.rb
+++ b/examples/motd_server/spec/ione/motd_server_spec.rb
@@ -2,6 +2,7 @@
 
 require 'ione/motd_server'
 
+require 'tempfile'
 
 module Ione
   describe MotdServer do

--- a/lib/ione/io/io_reactor.rb
+++ b/lib/ione/io/io_reactor.rb
@@ -130,7 +130,7 @@ module Ione
           @started_promise.fulfill(self)
           begin
             until @stopped
-              @io_loop.tick
+              @io_loop.tick(@scheduler.timeout)
               @scheduler.tick
             end
           ensure
@@ -444,7 +444,7 @@ module Ione
         end
       end
 
-      def tick(tick_timeout = @timeout)
+      def tick(tick_timeout = nil)
         readables = []
         writables = []
         connecting = []
@@ -459,7 +459,7 @@ module Ione
           end
         end
         begin
-          r, w, _ = @selector.select(readables, writables, nil, tick_timeout)
+          r, w, _ = @selector.select(readables, writables, nil, tick_timeout || @timeout)
           connecting.each { |s| s.connect }
           r && r.each { |s| s.read }
           w && w.each { |s| s.flush }

--- a/lib/ione/io/io_reactor.rb
+++ b/lib/ione/io/io_reactor.rb
@@ -471,6 +471,7 @@ module Ione
         end
         begin
           select_timeout = tick_timeout || @timeout
+          select_timeout = 0 if select_timeout < 0
           @next_timeout_time = @clock.now + select_timeout
           r, w, _ = @selector.select(readables, writables, nil, select_timeout)
           connecting.each { |s| s.connect }

--- a/lib/ione/io/io_reactor.rb
+++ b/lib/ione/io/io_reactor.rb
@@ -444,7 +444,7 @@ module Ione
         end
       end
 
-      def tick
+      def tick(tick_timeout = @timeout)
         readables = []
         writables = []
         connecting = []
@@ -459,7 +459,7 @@ module Ione
           end
         end
         begin
-          r, w, _ = @selector.select(readables, writables, nil, @timeout)
+          r, w, _ = @selector.select(readables, writables, nil, tick_timeout)
           connecting.each { |s| s.connect }
           r && r.each { |s| s.read }
           w && w.each { |s| s.flush }

--- a/lib/ione/io/io_reactor.rb
+++ b/lib/ione/io/io_reactor.rb
@@ -543,6 +543,11 @@ module Ione
         end
       end
 
+      def timeout
+        next_timer = @timer_queue.peek
+        next_timer && next_timer.time - @clock.now
+      end
+
       def to_s
         %(#<#{self.class.name} @timers=[#{@pending_timers.values.map(&:to_s).join(', ')}]>)
       end

--- a/spec/integration/io_spec.rb
+++ b/spec/integration/io_spec.rb
@@ -8,6 +8,22 @@ describe 'An IO reactor' do
     Ione::Io::IoReactor.new
   end
 
+  context 'schedules timers' do
+    let :io_reactor do
+      Ione::Io::IoReactor.new(tick_resolution: 3)
+    end
+
+    it 'resolves timers on time even when they expire before the reactor is scheduled to wake up next' do
+      io_reactor.start.value
+      start_time = Time.now
+      timer_future = io_reactor.schedule_timer(0.3)
+      io_reactor.schedule_timer(0.1).value
+      (Time.now - start_time).should <= 0.2
+      timer_future.value
+      (Time.now - start_time).should <= 0.4
+    end
+  end
+
   context 'connecting to a generic server' do
     let :protocol_handler_factory do
       lambda { |c| IoSpec::TestConnection.new(c) }

--- a/spec/ione/io/io_reactor_spec.rb
+++ b/spec/ione/io/io_reactor_spec.rb
@@ -255,6 +255,10 @@ module Ione
       end
 
       describe '#schedule_timer' do
+        let :clock do
+          double(:clock, now: 1)
+        end
+
         let :reactor do
           described_class.new(selector: selector, clock: clock, tick_resolution: 2)
         end
@@ -268,14 +272,12 @@ module Ione
         end
 
         it 'returns a future that is resolved after the specified duration' do
-          clock.stub(:now).and_return(1)
           f = reactor.schedule_timer(0.1)
           clock.stub(:now).and_return(1.1)
           await { f.resolved? }
         end
 
         it 'uses the time until the timer expires as the next select timeout' do
-          clock.stub(:now).and_return(1)
           f = reactor.schedule_timer(0.1).flat_map do
             timeout = selector.last_arguments[3]
             Future.resolved(timeout)
@@ -283,6 +285,20 @@ module Ione
           clock.stub(:now).and_return(1.1)
           await { f.resolved? }
           f.value.should <= 0.1
+        end
+
+        it 'unblocks the reactor when the timeout occurs before the next tick' do
+          reactor.should_receive(:unblock)
+          f = reactor.schedule_timer(0.1)
+          clock.stub(:now).and_return(1.2)
+          await { f.resolved? }
+        end
+
+        it 'does not unblock the reactor when the timeout occurs after the next tick' do
+          reactor.should_not_receive(:unblock)
+          f = reactor.schedule_timer(2.1)
+          clock.stub(:now).and_return(3.2)
+          await { f.resolved? }
         end
       end
 
@@ -456,6 +472,22 @@ module Ione
           loop_body = described_class.new(selector: selector, clock: clock, tick_resolution: 99)
           selector.should_receive(:select).with(anything, anything, anything, 2).and_return([[], [], []])
           loop_body.tick(2)
+        end
+      end
+
+      describe '#next_tick_before?' do
+        before do
+          selector.stub(:select)
+        end
+
+        it 'returns true if the given time occurs after the next tick' do
+          loop_body.tick
+          loop_body.next_tick_before?(3).should be_true
+        end
+
+        it 'returns false if the given time occurs before the next tick' do
+          loop_body.tick
+          loop_body.next_tick_before?(0.5).should be_false
         end
       end
 

--- a/spec/ione/io/io_reactor_spec.rb
+++ b/spec/ione/io/io_reactor_spec.rb
@@ -436,6 +436,12 @@ module Ione
           selector.should_receive(:select).with(anything, anything, anything, 99).and_return([[], [], []])
           loop_body.tick
         end
+
+        it 'uses the specified timeout instead of the default' do
+          loop_body = described_class.new(selector: selector, clock: clock, tick_resolution: 99)
+          selector.should_receive(:select).with(anything, anything, anything, 2).and_return([[], [], []])
+          loop_body.tick(2)
+        end
       end
 
       describe '#close_sockets' do

--- a/spec/ione/io/io_reactor_spec.rb
+++ b/spec/ione/io/io_reactor_spec.rb
@@ -255,6 +255,10 @@ module Ione
       end
 
       describe '#schedule_timer' do
+        let :reactor do
+          described_class.new(selector: selector, clock: clock, tick_resolution: 2)
+        end
+
         before do
           reactor.start.value
         end
@@ -268,6 +272,17 @@ module Ione
           f = reactor.schedule_timer(0.1)
           clock.stub(:now).and_return(1.1)
           await { f.resolved? }
+        end
+
+        it 'uses the time until the timer expires as the next select timeout' do
+          clock.stub(:now).and_return(1)
+          f = reactor.schedule_timer(0.1).flat_map do
+            timeout = selector.last_arguments[3]
+            Future.resolved(timeout)
+          end
+          clock.stub(:now).and_return(1.1)
+          await { f.resolved? }
+          f.value.should <= 0.1
         end
       end
 

--- a/spec/ione/io/io_reactor_spec.rb
+++ b/spec/ione/io/io_reactor_spec.rb
@@ -489,6 +489,24 @@ module Ione
           future.should be_completed
           expect { scheduler.tick }.to_not raise_error
         end
+
+        it 'returns the time until the next timer expires' do
+          clock.stub(:now).and_return(1)
+          scheduler.schedule_timer(4)
+          clock.stub(:now).and_return(2)
+          scheduler.tick
+          scheduler.timeout.should == 3
+        end
+
+        it 'returns nil if there are no scheduled timers' do
+          clock.stub(:now).and_return(1)
+          scheduler.tick
+          scheduler.timeout.should be_nil
+          scheduler.schedule_timer(1)
+          clock.stub(:now).and_return(3)
+          scheduler.tick
+          scheduler.timeout.should be_nil
+        end
       end
 
       describe '#cancel_timers' do


### PR DESCRIPTION
The default `tick_resolution` timeout is 1 second which means that timers that are scheduled under periods when no IO activity is present will only get the chance to run once every second. This pr adds a bit of intelligence to the value of timeout in the `IO.select`call. Specifically if timers are scheduled we will disregard the `tick_resolution` and only wait for IO until it is time to run the first timer.

When scheduling timers from outside the Io::Reactor the reactor may currently be fast asleep in a `IO.select` call. Therefore we should unblock and run `scheduler.tick` once more to run the recently added timer if the added timer timeout is shorter than the earliest present timer or if there is no present timer.