### PR TITLE
Proof-of-concept destructive future combinators

### DIFF
--- a/spec/ione/future_spec.rb
+++ b/spec/ione/future_spec.rb
@@ -316,16 +316,16 @@ module Ione
 
         it 'notifies all listeners when the promise is fulfilled, even when one raises an error' do
           value = nil
-          future.on_complete { |f| raise 'Blurgh' }
-          future.on_complete { |f| value = f.value }
+          future.on_complete { raise 'Blurgh' }
+          future.on_complete { |v, _| value = v }
           promise.fulfill('bar')
           value.should == 'bar'
         end
 
         it 'notifies all listeners when the promise fails, even when one raises an error' do
           err = nil
-          future.on_complete { |f| raise 'Blurgh' }
-          future.on_complete { |f| begin; f.value; rescue => err; e = err; end }
+          future.on_complete { raise 'Blurgh' }
+          future.on_complete { |_, e| err = e }
           promise.fail(error)
           err.message.should == 'bork'
         end


### PR DESCRIPTION
Implement destructive versions of the combinators, that updates the
existing future rather than creating a new one. The new combinators
ought to be thread-safe, but interleaving destructive updates might
produce counter-intuitive results sometimes. However, the common use
case seems to be synchronous construction of an asynchronous future
chain, in which case these combinators might reduce memory footprint
and call stack depth.

This is made possible by not resolving a future until after the
callbacks have completed. This is obviously a backwards-incompatible
change, as it causes any code with a `#value` in a callback to hang
indefinitely.

An obvious alternative would be to treat "transformations" and
"callbacks" separately, but I tried to avoid introducing further
bookkeeping surrounding the callbacks. 

Another advantage of keeping callbacks and transformations in a list
is that synchronous transformations behave as expected. That is, if
you add a listener before and after a `map!` is applied, the first
callback will receive the unmapped value, and the second callback will
receive the transformed value.

The future chaining transformations (`flat_map`, `then` and `fallback`)
requires some way to stop the listener dispatch in order to implement
the destructive versions. Here, this is accomplished by using the
return value of the listener callback. There is probably a better way
to get the same effect. To avoid breaking existing callbacks, this was
separated into the `on_complete!` callback.

To avoid too much code duplication, the non-destructive operation `foo`
is implemented using `dup.foo!`, similar to how non-destructive array
operations can be implemented. Not quite sure `dup` is the right name
for the newly constructed future (observing on the original), though.

I made some minor adjustments to the remaining code to get the future
specs to pass, but these are probably not 100% correct.

I have not (yet) made any performance comparisons with the existing
implementations. These changes are obviously not worth the trouble
unless the destructive operations are significantly cheaper than the
previous implementation of their non-destructive counterparts.

For now, the destructive methods are only tested through the existing
tests for the non-destructive versions. Further tests and documentation
would definitely be necessary to better describe the semantics.