### PR TITLE
Avoid stack overflow error with Future.after

### DIFF
--- a/spec/ione/future_spec.rb
+++ b/spec/ione/future_spec.rb
@@ -1047,6 +1047,12 @@ module Ione
           future = Future.after(ff1, ff2, ff3)
           future.value.should be_nil
         end
+
+        it 'handles a really long list of futures' do
+          futures = Array.new(10000, Future.resolved)
+          future = Future.after(futures)
+          future.value.should be_nil
+        end
       end
     end
 


### PR DESCRIPTION
This is an attempt at solving #28, without introducing the need to protecting the compound nil future with locks. It should be noted that I have not (yet) performed any extensive tests with respect to the thread safety of the solution.

With a long list of resolved futures, the previous implementation caused a stack-overflow exception, as each call to await_next happened within the previous call (synchronously).

This changes the behavior to loop over futures instead of using recursion while on_complete dispatches synchronously in the same thread. To avoid code duplication we always dispatch in the terminating cases,
even if it introduces an extra stack frame. The looping condition protects against cases where a future would be resolved at a later point by the calling thread (which is what the tests do), and the last part of the condition protects against dispatching in other threads.

While the algorithm looks like a loop that adds multiple concurrent on_complete listeners, the intention is in fact still to only ever have one concurrent listener, making sure that the combined nil future is only ever accessed from one thread at a time (without using locks).

