### PR TITLE
Don't attempt to lock twice when draining

### DIFF
--- a/lib/ione/io/base_connection.rb
+++ b/lib/ione/io/base_connection.rb
@@ -145,6 +145,7 @@ module Ione
 
       # @private
       def flush
+        should_close = false
         if @state == CONNECTED_STATE || @state == DRAINING_STATE
           @lock.lock
           begin
@@ -154,11 +155,12 @@ module Ione
             end
             @writable = !@write_buffer.empty?
             if @state == DRAINING_STATE && !@writable
-              close
+              should_close = true
             end
           ensure
             @lock.unlock
           end
+          close if should_close
         end
       rescue => e
         close(e)

--- a/spec/ione/io/connection_common.rb
+++ b/spec/ione/io/connection_common.rb
@@ -90,6 +90,13 @@ shared_examples_for 'a connection' do |options|
       handler.flush
       f.should be_completed
     end
+
+    it 'does not attempt to acquire the lock multiple times from the same thread' do
+      handler.write('hello world')
+      f = handler.drain
+      handler.flush
+      expect { f.value }.to_not raise_error
+    end
   end
 
   describe '#write/#flush' do


### PR DESCRIPTION
When the connection is in the "draining" state and the connection isn't writable it'll attempt to close the connection (this happens in `#flush` by the way). This is done while holding the lock, though the first thing that `#close` does it to attempt to acquire the lock, which will result in a ThreadError (Mutex relocking by same thread). Ultimately we'll end up with a future, and when we call `#value` on said future we'll get an Ione::Io::ConnectionClosedError exception with "Mutex relocking by same thread" as the error message.

I'm not at all sure if this is the best solution though.