### PR TITLE
Allow intercepting listener errors more easily

### DIFF
--- a/lib/ione/future.rb
+++ b/lib/ione/future.rb
@@ -739,31 +739,10 @@ module Ione
       end
     end
 
-    class <<self
-      # Set the global listener for handling uncaught errors in other registered
-      # future listeners. The listener will be called with the error that failed
-      # the future as sole argument.
-      #
-      # Errors raised from the global listener will be ignored.
-      #
-      # By default, the global error handler does nothing.
-      #
-      # @example
-      #   Future.on_listener_error do do |error|
-      #     LOGGER.warn("Uncaught error: #{error} (#{error.class})")
-      #   end
-      #
-      # @yieldparam [Object] error the uncaught error from the listener dispatch
-      def on_listener_error(&listener_error_handler)
-        @listener_error_handler = listener_error_handler
-        nil
-      end
-
-      # @private
-      attr_reader :listener_error_handler
-    end
-
     private
+
+    def discard_error(e)
+    end
 
     def call_listener(listener)
       begin
@@ -778,13 +757,7 @@ module Ione
           listener.call(@value, @error, self)
         end
       rescue => e
-        begin
-          if (error_handler = Ione::Future.listener_error_handler)
-            error_handler.call(e)
-          end
-        rescue
-          # swallowed
-        end
+        discard_error(e)
       end
     end
   end

--- a/spec/ione/future_spec.rb
+++ b/spec/ione/future_spec.rb
@@ -127,6 +127,20 @@ module Ione
       StandardError.new('bork')
     end
 
+    let :listener_error_handler do
+      double(:listener_error_handler)
+    end
+
+    before do
+      @old_error_handler = Ione::Future.listener_error_handler
+      listener_error_handler.stub(:call)
+      Ione::Future.on_listener_error { |error| listener_error_handler.call(error) }
+    end
+
+    after do
+      Ione::Future.on_listener_error(&@old_error_handler)
+    end
+
     def async(*context, &listener)
       Thread.start(*context, &listener)
     end
@@ -330,6 +344,22 @@ module Ione
           err.message.should == 'bork'
         end
 
+        it 'notifies the global error listener when one raises an error' do
+          future.on_complete { |f| raise IoError, 'Blurgh' }
+          future.on_complete { |f| 'foo' }
+          promise.fulfill('bar')
+          listener_error_handler.should have_received(:call).with(kind_of(IoError))
+        end
+
+        it 'notifies all listeners when the promise is fulfilled, even when one raises an error and the global error listener raises an error' do
+          value = nil
+          listener_error_handler.stub(:call).and_raise(RuntimeError, 'bork')
+          future.on_complete { |f| raise 'Blurgh' }
+          future.on_complete { |f| value = f.value }
+          promise.fulfill('bar')
+          value.should == 'bar'
+        end
+
         it 'notifies listeners registered after the promise was fulfilled' do
           f, v, e = nil, nil, nil
           promise.fulfill('bar')
@@ -348,8 +378,20 @@ module Ione
           e.message.should == 'bork'
         end
 
-        it 'notifies listeners registered after the promise failed' do
+        it 'does not raise any error when the listener raises an error when already failed' do
           promise.fail(error)
+          expect { future.on_complete { raise 'blurgh' } }.to_not raise_error
+        end
+
+        it 'notifies the global error listener when one raises an error when future already failed' do
+          promise.fail(error)
+          expect { future.on_complete { raise IoError, 'blurgh' } }.to_not raise_error
+          listener_error_handler.should have_received(:call).with(kind_of(IoError))
+        end
+
+        it 'does not raise any error when the global error listener fails when future already failed' do
+          promise.fail(error)
+          listener_error_handler.stub(:call).and_raise(RuntimeError, 'bork')
           expect { future.on_complete { raise 'blurgh' } }.to_not raise_error
         end
 
@@ -388,6 +430,22 @@ module Ione
           value.should == 'bar'
         end
 
+        it 'notifies the global error listener when one raises an error' do
+          future.on_value { |v| raise IoError, 'Blurgh' }
+          future.on_value { |v| 'foo' }
+          promise.fulfill('bar')
+          listener_error_handler.should have_received(:call).with(kind_of(IoError))
+        end
+
+        it 'notifies all listeners when the promise is fulfilled, even when one raises an error and the global error listener raises an error' do
+          value = nil
+          listener_error_handler.stub(:call).and_raise(RuntimeError, 'bork')
+          future.on_value { |v| raise 'Blurgh' }
+          future.on_value { |v| value = v }
+          promise.fulfill('bar')
+          value.should == 'bar'
+        end
+
         it 'notifies listeners registered after the promise was resolved' do
           v1, v2 = nil, nil
           promise.fulfill('bar')
@@ -400,6 +458,18 @@ module Ione
         it 'does not raise any error when the listener raises an error when already resolved' do
           promise.fulfill('bar')
           expect { future.on_value { |v| raise 'blurgh' } }.to_not raise_error
+        end
+
+        it 'notifies the global error listener when one raises an error when future already resolved' do
+          promise.fulfill('bar')
+          expect { future.on_value { raise IoError, 'blurgh' } }.to_not raise_error
+          listener_error_handler.should have_received(:call).with(kind_of(IoError))
+        end
+
+        it 'does not raise any error when the global error listener fails when future already resolved' do
+          promise.fulfill('bar')
+          listener_error_handler.stub(:call).and_raise(RuntimeError, 'bork')
+          expect { future.on_value { raise 'blurgh' } }.to_not raise_error
         end
 
         it 'returns nil' do
@@ -432,6 +502,24 @@ module Ione
           e.message.should eql(error.message)
         end
 
+        it 'notifies the global error listener when one raises an error' do
+          e = nil
+          future.on_failure { |err| raise IoError, 'Blurgh' }
+          future.on_failure { |err| e = err }
+          promise.fail(error)
+          listener_error_handler.should have_received(:call).with(kind_of(IoError))
+          e.message.should eql(error.message)
+        end
+
+        it 'notifies all listeners when the promise is fulfilled, even when one raises an error and the global error listener raises an error' do
+          e = nil
+          listener_error_handler.stub(:call).and_raise(RuntimeError, 'bork')
+          future.on_failure { |err| raise 'Blurgh' }
+          future.on_failure { |err| e = err }
+          promise.fail(error)
+          e.message.should eql(error.message)
+        end
+
         it 'notifies new listeners even when already failed' do
           e1, e2 = nil, nil
           promise.fail(error)
@@ -444,6 +532,18 @@ module Ione
         it 'does not raise any error when the listener raises an error when already failed' do
           promise.fail(error)
           expect { future.on_failure { |e| raise 'Blurgh' } }.to_not raise_error
+        end
+
+        it 'notifies the global error listener when one raises an error when future already failed' do
+          promise.fail(error)
+          expect { future.on_failure { raise IoError, 'blurgh' } }.to_not raise_error
+          listener_error_handler.should have_received(:call).with(kind_of(IoError))
+        end
+
+        it 'does not raise any error when the global error listener fails when future already failed' do
+          promise.fail(error)
+          listener_error_handler.stub(:call).and_raise(RuntimeError, 'bork')
+          expect { future.on_failure { raise 'blurgh' } }.to_not raise_error
         end
 
         it 'returns nil' do


### PR DESCRIPTION
As is, any exception in an either of the future listener callbacks will just be swallowed. This makes debugging of future-related problems much harder than it needs to be.

This introduces an indirection method that can be monkey-patched in an application in order to capture these failures. This is clearly not the ideal interface, but I'm not sure how this could be handled better, without making major changes to Ione.

This originally injected a global listener error handler. But given the motivation for the feature, this was deemed a way too general implementation. There should be only one listener per application, and any library building on top of Ione definitely shouldn't register a listener for these errors.
