### PR TITLE
Optimize combinators for resolved cases

### DIFF
--- a/lib/ione/future.rb
+++ b/lib/ione/future.rb
@@ -209,6 +209,8 @@ module Ione
         end
         if futures.count == 0
           resolved([])
+        elsif (failed = futures.find { |f| f.respond_to?(:failed?) && f.failed? })
+          failed
         else
           CombinedFuture.new(futures)
         end
@@ -231,6 +233,7 @@ module Ione
         if futures.size == 1 && (fs = futures.first).is_a?(Enumerable)
           *futures = *fs
         end
+        futures.reject! { |f| f.respond_to?(:resolved?) && f.resolved? }
         if futures.count == 0
           ResolvedFuture::NIL
         elsif futures.count == 1
@@ -262,7 +265,9 @@ module Ione
           futures = fs
         end
         if futures.count == 0
-          resolved
+          ResolvedFuture::NIL
+        elsif (done = futures.find { |f| f.respond_to?(:resolved?) && f.resolved? })
+          done
         else
           FirstFuture.new(futures)
         end


### PR DESCRIPTION
This implements three optimizations, for three different combinators.

For `Future::all`, if a future is already known to be failed, we know upfront that the result will be a failed future, and we can reuse this result.

For `Future::after`, if a future is already resolved, there is no reason to keep it in the waiting list.

For `Future::first`, if a future is already known to be resolved, we know upfront that the result will be a resolved future, and we can reuse this result.

The implementations rely on `resolved?` and `failed?`, which according to the specs are not guaranteed to exist on a future, and thus the code has to check their presence before doing anything about it.