### PR TITLE
Avoid stack overflow error with Future.reduce

### DIFF
--- a/spec/ione/future_spec.rb
+++ b/spec/ione/future_spec.rb
@@ -916,6 +916,12 @@ module Ione
         future.value.should == 6
       end
 
+      it 'handles a really long list of futures' do
+        futures = Array.new(10000, Future.resolved(1))
+        future = Future.reduce(futures, 0, &:+)
+        future.value.should eq(10000)
+      end
+
       context 'when the :ordered option is false' do
         it 'calls the block with the values in the order of completion, when the :ordered option is false' do
           promises = [Promise.new, Promise.new, Promise.new]
@@ -947,6 +953,12 @@ module Ione
             end
           end
           future.should be_failed
+        end
+
+        it 'handles a really long list of futures' do
+          futures = Array.new(10000, Future.resolved(1))
+          future = Future.reduce(futures, 0, ordered: false, &:+)
+          future.value.should eq(10000)
         end
 
         context 'when the list of futures is empty' do


### PR DESCRIPTION
This completely splits the implementation between the ordered and unordered reduce, as it becomes rather difficult to share code between the two.

This tweaks the internal interface slightly, in particular by not using an instance variable for the accumulator in either case.

With a long list of resolved futures, the previous implementation of an ordered reduce caused a stack-overflow exception, as each call to `reduce_next` happened within the previous call (synchronously).

This changes the behavior to loop over futures instead of using recursion while `on_complete` dispatches synchronously in the same thread. The implementation is heavily based on the non-recursive implementation of `Future.after`.