### PR TITLE
Add non-raising variants of Promise#fulfill and Promise#fail

### DIFF
--- a/lib/ione/future.rb
+++ b/lib/ione/future.rb
@@ -34,7 +34,7 @@ module Ione
     # Fulfills the promise like {#fulfill}, but returns false instead of raising.
     #
     # @param [Object] value the value of the future
-    # @return [true, false] returns false if the connection was already closed
+    # @return [true, false] returns false if the promise was already completed.
     def try_fulfill(value=nil)
       @future.try_resolve(value)
     end
@@ -53,7 +53,7 @@ module Ione
     # Fails the promise like {#fail}, but returns false instead of raising.
     #
     # @param [Error] error the error which prevented the promise to be fulfilled
-    # @raise [FutureError] if the promise was already completed.
+    # @return [true, false] returns false if the promise was already completed.
     def try_fail(error)
       @future.try_fail(error)
     end

--- a/lib/ione/future.rb
+++ b/lib/ione/future.rb
@@ -857,7 +857,7 @@ module Ione
         f.on_complete do |v, e|
           unless failed?
             if e
-              fail(e)
+              try_fail(e)
             else
               @lock.lock
               begin
@@ -983,7 +983,7 @@ module Ione
           f.on_complete do |v, e|
             unless failed?
               if e
-                fail(e)
+                try_fail(e)
               else
                 done = false
                 @lock.lock
@@ -993,7 +993,7 @@ module Ione
                   done = (remaining == 0)
                 rescue => ee
                   @lock.unlock
-                  fail(ee)
+                  try_fail(ee)
                 else
                   @lock.unlock
                 end
@@ -1021,7 +1021,7 @@ module Ione
                 fail(e)
               end
             else
-              resolve(v)
+              try_resolve(v)
             end
           end
         end

--- a/lib/ione/io/connection.rb
+++ b/lib/ione/io/connection.rb
@@ -63,9 +63,7 @@ module Ione
         if cause && !cause.is_a?(IoError)
           cause = ConnectionError.new(cause.message)
         end
-        unless @connected_promise.future.completed?
-          @connected_promise.fail(cause)
-        end
+        @connected_promise.try_fail(cause)
       end
     end
   end

--- a/lib/ione/io/ssl_connection.rb
+++ b/lib/ione/io/ssl_connection.rb
@@ -72,9 +72,7 @@ module Ione
         if cause && !cause.is_a?(IoError)
           cause = ConnectionError.new(cause.message)
         end
-        unless @connected_promise.future.completed?
-          @connected_promise.fail(cause)
-        end
+        @connected_promise.try_fail(cause)
       end
     end
   end

--- a/spec/ione/future_spec.rb
+++ b/spec/ione/future_spec.rb
@@ -38,7 +38,7 @@ module Ione
       end
     end
 
-    describe '#fulfill' do
+    describe '#try_fulfill' do
       it 'resolves its future' do
         promise.try_fulfill
         future.should be_resolved
@@ -48,7 +48,7 @@ module Ione
         promise.try_fulfill(:foo).should eq(true)
       end
 
-      it 'raises an error if fulfilled a second time' do
+      it 'returns false if fulfilled a second time' do
         promise.try_fulfill
         promise.try_fulfill.should eq(false)
       end

--- a/spec/ione/future_spec.rb
+++ b/spec/ione/future_spec.rb
@@ -38,6 +38,22 @@ module Ione
       end
     end
 
+    describe '#fulfill' do
+      it 'resolves its future' do
+        promise.try_fulfill
+        future.should be_resolved
+      end
+
+      it 'returns true' do
+        promise.try_fulfill(:foo).should eq(true)
+      end
+
+      it 'raises an error if fulfilled a second time' do
+        promise.try_fulfill
+        promise.try_fulfill.should eq(false)
+      end
+    end
+
     describe '#fail' do
       it 'fails its future' do
         promise.fail(error)
@@ -56,6 +72,22 @@ module Ione
 
       it 'returns nil' do
         promise.fail(error).should be_nil
+      end
+    end
+
+    describe '#try_fail' do
+      it 'fails its future' do
+        promise.try_fail(error)
+        future.should be_failed
+      end
+
+      it 'returns true' do
+        promise.try_fail(error).should eq(true)
+      end
+
+      it 'returns false if failed a second time' do
+        promise.try_fail(error)
+        promise.try_fail(error).should eq(false)
       end
     end
 


### PR DESCRIPTION
In cases where a promise might be fulfilled or failed concurrently from multiple threads, it is expected that completing the future might fail due to already have been completed in another thread.

Even if you query the future for completed status, nothing guarantees that the future isn't completed between the status check and you next call. In order to avoid having to rescue the expected exception in this case, this allows you to just try to fail or fulfill the promise.

In addition, this changes the internals at various places to use the non-raising variants in cases where a raise condition is expected. This is mainly done to make the code easier to understand, as the difference will not really be externally visible, as most are called from listener blocks where all errors will be swallowed anyhow. In much the same way, cases where concurrent calls are not expected are kept the way they are, even though it (theoretically) incurs a slight overhead to do so.
