### PR TITLE
Make sure reactor is running while stopping

### DIFF
--- a/lib/ione/io/io_reactor.rb
+++ b/lib/ione/io/io_reactor.rb
@@ -124,7 +124,7 @@ module Ione
       # after {#stop} has been called, but false when the future returned by
       # {#stop} completes.
       def running?
-        @state == RUNNING_STATE
+        (state = @state) == RUNNING_STATE || state == STOPPING_STATE
       end
 
       # Starts the reactor. This will spawn a background thread that will manage

--- a/spec/ione/io/io_reactor_spec.rb
+++ b/spec/ione/io/io_reactor_spec.rb
@@ -172,10 +172,25 @@ module Ione
           reactor.stop.value.should equal(reactor)
         end
 
-        it 'is not running after being stopped' do
+        it 'is not running after stop completed' do
           reactor.start.value
           reactor.stop.value
           reactor.should_not be_running
+        end
+
+        it 'keeps running until stop completed' do
+          running_barrier = Queue.new
+          stop_barrier = Queue.new
+          selector.handler do
+            running_barrier.push(nil)
+            stop_barrier.pop
+            [[], [], []]
+          end
+          reactor.start.value
+          future = reactor.stop
+          running_barrier.pop
+          reactor.should be_running
+          stop_barrier.push(nil) until future.completed?
         end
 
         it 'closes all sockets' do


### PR DESCRIPTION
The documentation says it should be like that.

This should also somewhat improve the reactor tests that inject a blocking selector, as it will allow the reactor loop to continue until completely stopped.