### PR TITLE
Drain buffered socket writes when closing the reactor

### DIFF
--- a/lib/ione/io/acceptor.rb
+++ b/lib/ione/io/acceptor.rb
@@ -77,6 +77,9 @@ module Ione
       end
 
       # @private
+      alias_method :drain, :close
+
+      # @private
       def to_io
         @io
       end

--- a/lib/ione/io/io_reactor.rb
+++ b/lib/ione/io/io_reactor.rb
@@ -198,6 +198,7 @@ module Ione
             Future.resolved(self)
           elsif @state != STOPPED_STATE && @state != CRASHED_STATE
             @state = STOPPING_STATE
+            @unblocker.unblock
             @stopped_promise.future
           else
             @stopped_promise.future

--- a/lib/ione/io/io_reactor.rb
+++ b/lib/ione/io/io_reactor.rb
@@ -498,10 +498,10 @@ module Ione
 
       def drain_sockets
         threshold = @clock.now + @drain_timeout
-        until @clock.now >= threshold || @sockets.none? { |s| s.writable? }
+        until @clock.now >= threshold || @sockets.none?(&:writable?)
           @sockets.each(&:drain)
           tick
-          @lock.synchronize { @sockets = @sockets.reject { |s| s.closed? } }
+          @lock.synchronize { @sockets = @sockets.reject(&:closed?) }
         end
         if @clock.now >= threshold
           raise ReactorError, sprintf('Socket drain timeout after %p s', @drain_timeout)

--- a/spec/ione/io/connection_common.rb
+++ b/spec/ione/io/connection_common.rb
@@ -83,6 +83,19 @@ shared_examples_for 'a connection' do |options|
       handler.should be_closed
     end
 
+    it 'closes the socket for reading if possible' do
+      socket.stub(:close_read)
+      handler.write('hello world')
+      handler.drain
+      socket.should have_received(:close_read)
+    end
+
+    it 'ignores IO errors when closing for reading' do
+      socket.stub(:close_read).and_raise(IOError, 'Boork')
+      handler.write('hello world')
+      expect { handler.drain }.to_not raise_error
+    end
+
     it 'returns a future that completes when the socket has closed' do
       handler.write('hello world')
       f = handler.drain

--- a/spec/ione/io/io_reactor_spec.rb
+++ b/spec/ione/io/io_reactor_spec.rb
@@ -7,7 +7,11 @@ module Ione
   module Io
     describe IoReactor do
       let :reactor do
-        described_class.new(selector: selector, clock: clock)
+        described_class.new(options)
+      end
+
+      let :options do
+        {selector: selector, clock: clock, drain_timeout: 3}
       end
 
       let! :selector do
@@ -206,6 +210,59 @@ module Ione
             end
             reactor.stop.value
             connection.should have_received(:flush)
+          end
+        end
+
+        it 'waits on drain to complete upto the specified drain timeout' do
+          time = time_increment = next_increment = 0
+          mutex = Mutex.new
+          selector.handler do |_, writables, _, _|
+            mutex.synchronize do
+              clock.stub(:now).and_return(time += time_increment)
+              time_increment = next_increment
+            end
+            [[], writables, []]
+          end
+          reactor.start.value
+          TCPServer.open(0) do |server|
+            lazy_socket = Thread.start { server.accept }
+            connection = reactor.connect(server.addr[3], server.addr[1], 5).value
+            stopped_future = nil
+            mutex.synchronize do
+              connection.stub(:writable?).and_return(true)
+              connection.stub(:flush)
+              next_increment = 1
+              stopped_future = reactor.stop
+            end
+            expect { stopped_future.value }.to raise_error(ReactorError, /timeout/)
+            (time).should eq(3)
+          end
+        end
+
+        it 'waits on drain to complete upto five seconds by default' do
+          options.delete(:drain_timeout)
+          time = time_increment = next_increment = 0
+          mutex = Mutex.new
+          selector.handler do |_, writables, _, _|
+            mutex.synchronize do
+              clock.stub(:now).and_return(time += time_increment)
+              time_increment = next_increment
+            end
+            [[], writables, []]
+          end
+          reactor.start.value
+          TCPServer.open(0) do |server|
+            lazy_socket = Thread.start { server.accept }
+            connection = reactor.connect(server.addr[3], server.addr[1], 5).value
+            stopped_future = nil
+            mutex.synchronize do
+              connection.stub(:writable?).and_return(true)
+              connection.stub(:flush)
+              next_increment = 1
+              stopped_future = reactor.stop
+            end
+            expect { stopped_future.value }.to raise_error(ReactorError, /timeout/)
+            (time).should eq(5)
           end
         end
 

--- a/spec/ione/io/io_reactor_spec.rb
+++ b/spec/ione/io/io_reactor_spec.rb
@@ -196,6 +196,20 @@ module Ione
           stop_barrier.push(nil) until future.completed?
         end
 
+        it 'unblocks the reactor' do
+          running_barrier = Queue.new
+          selector.handler do |readables, writables, _, _|
+            running_barrier.push(nil)
+            IO.select(readables, writables, nil, 5)
+          end
+          reactor.start.value
+          running_barrier.pop
+          stopped_future = reactor.stop
+          sleep 0.5
+          stopped_future.should be_completed
+          stopped_future.value
+        end
+
         it 'drains all sockets' do
           reactor.start.value
           TCPServer.open(0) do |server|


### PR DESCRIPTION
The draining is a simple loop that tries to drain all the sockets until all write buffers are empty. Technically, this only flushes the application buffers, and there is no guarantee that the kernel and network actually manages to get the bytes to the other side.

The draining is done with a timeout (which is currently hard-coded), and in the event that draining fails, the reactor stop will also fail, but all the existing shutdown logic will still be performed.

In order to not have to make the drain call conditional, the unblocker and the acceptors implement drain methods. For the acceptor, the distinction between drain and close doesn't make any sense, so in this case it is just a simple alias. While the unblocker shouldn't be needed during the drain, I wasn't 100% sure that is would be safe, so there drain does nothing.

This also extends the drain procedure to close the sockets for reading while draining the write buffer.

I found it quite challenging to write tests for this. The current reactor test is I guess more of an integration test rather than a unit test, as it still relies on a real remote server socket and the real IO selector. 