### PR TITLE
Replace Future#value with Future.await

### DIFF
--- a/lib/ione/future.rb
+++ b/lib/ione/future.rb
@@ -610,11 +610,8 @@ module Ione
           semaphore << [value, error]
         end
         value, error = semaphore.pop
-        if f.resolved?
-          value
-        else
-          raise error
-        end
+        raise error if error
+        value
       end
     end
 

--- a/lib/ione/future.rb
+++ b/lib/ione/future.rb
@@ -590,7 +590,36 @@ module Ione
       end
     end
 
+    # @since v1.x.x
+    module Blockers
+      # Awaits the completion of a future and either returns the value or raises
+      # an error.
+      #
+      # @note
+      #   This is a blocking operation and should be used with caution. You should
+      #   never call this method in a block given to any of the other methods
+      #   on {Future}. Prefer using combinator methods like {#map} and {#flat_map}
+      #   to compose operations asynchronously, or use {#on_value}, {#on_failure}
+      #   or {#on_complete} to listen for values and/or failures.
+      #
+      # @raise [Error] the error that failed this future
+      # @return [Object] the value of this future
+      def await(f)
+        semaphore = Queue.new
+        f.on_complete do |value, error|
+          semaphore << [value, error]
+        end
+        value, error = semaphore.pop
+        if f.resolved?
+          value
+        else
+          raise error
+        end
+      end
+    end
+
     extend Factories
+    extend Blockers
     include Combinators
     include Callbacks
 
@@ -674,35 +703,19 @@ module Ione
     #   to compose operations asynchronously, or use {#on_value}, {#on_failure}
     #   or {#on_complete} to listen for values and/or failures.
     #
+    # @deprecated
+    #   This method will be removed in the next major release.
+    #   Use {Future.await}. Synchronously waiting for the result of a future is
+    #   very rarely the right thing to do, and as the only blocking method on
+    #   {Future}, {#value} doesn't belong.
+    #
     # @raise [Error] the error that failed this future
     # @return [Object] the value of this future
     # @see Callbacks#on_value
     # @see Callbacks#on_failure
     # @see Callbacks#on_complete
     def value
-      raise @error if @state == FAILED_STATE
-      return @value if @state == RESOLVED_STATE
-      semaphore = nil
-      @lock.lock
-      begin
-        raise @error if @state == FAILED_STATE
-        return @value if @state == RESOLVED_STATE
-        semaphore = Queue.new
-        u = proc { semaphore << :unblock }
-        @listeners << u
-      ensure
-        @lock.unlock
-      end
-      while true
-        @lock.lock
-        begin
-          raise @error if @state == FAILED_STATE
-          return @value if @state == RESOLVED_STATE
-        ensure
-          @lock.unlock
-        end
-        semaphore.pop
-      end
+      Future.await(self)
     end
     alias_method :get, :value
 

--- a/spec/ione/byte_buffer_spec.rb
+++ b/spec/ione/byte_buffer_spec.rb
@@ -330,6 +330,28 @@ module Ione
         x.bytesize.should be <= buffer.bytesize
         buffer.to_str.should start_with(x)
       end
+
+      it 'considers contents in the write when read buffer consumed' do
+        buffer.append('foo')
+        buffer.append('bar')
+        buffer.read_byte
+        buffer.discard(5)
+        buffer.append('hello')
+        x = buffer.cheap_peek
+        x.bytesize.should be > 0
+        x.bytesize.should be <= buffer.bytesize
+        buffer.to_str.should start_with(x)
+      end
+
+      it 'returns nil in readonly mode when read buffer is consumed' do
+        buffer.append('foo')
+        buffer.append('bar')
+        buffer.read_byte
+        buffer.discard(5)
+        buffer.append('hello')
+        x = buffer.cheap_peek(true)
+        x.should be_nil
+      end
     end
 
     describe '#getbyte' do

--- a/spec/ione/io/io_reactor_spec.rb
+++ b/spec/ione/io/io_reactor_spec.rb
@@ -712,7 +712,11 @@ module Ione
 
     describe IoLoopBody do
       let :loop_body do
-        described_class.new(selector: selector, clock: clock)
+        described_class.new(unblocker, selector: selector, clock: clock)
+      end
+
+      let :unblocker do
+        double(:unblocker, connected?: true, connecting?: false, writable?: false, closed?: false)
       end
 
       let :selector do
@@ -727,14 +731,24 @@ module Ione
         double(:socket, connected?: false, connecting?: false, writable?: false, closed?: false)
       end
 
+      before do
+        unblocker.stub(:close) { unblocker.stub(:closed?).and_return(true) }
+      end
+
       describe '#tick' do
         before do
           loop_body.add_socket(socket)
         end
 
+        it 'passes the unblocker to the selector as the first readable' do
+          socket.stub(:connected?).and_return(true)
+          selector.should_receive(:select).with([unblocker, socket], anything, anything, anything).and_return([nil, nil, nil])
+          loop_body.tick
+        end
+
         it 'passes connected sockets as readables to the selector' do
           socket.stub(:connected?).and_return(true)
-          selector.should_receive(:select).with([socket], anything, anything, anything).and_return([nil, nil, nil])
+          selector.should_receive(:select).with([unblocker, socket], anything, anything, anything).and_return([nil, nil, nil])
           loop_body.tick
         end
 
@@ -747,7 +761,7 @@ module Ione
         it 'passes writable sockets as both readable and writable to the selector' do
           socket.stub(:connected?).and_return(true)
           socket.stub(:writable?).and_return(true)
-          selector.should_receive(:select).with([socket], [socket], anything, anything).and_return([nil, nil, nil])
+          selector.should_receive(:select).with([unblocker, socket], [socket], anything, anything).and_return([nil, nil, nil])
           loop_body.tick
         end
 
@@ -760,7 +774,7 @@ module Ione
 
         it 'filters out closed sockets' do
           socket.stub(:closed?).and_return(true)
-          selector.should_receive(:select).with([], [], anything, anything).and_return([nil, nil, nil])
+          selector.should_receive(:select).with([unblocker], [], anything, anything).and_return([nil, nil, nil])
           loop_body.tick
         end
 
@@ -804,7 +818,7 @@ module Ione
         end
 
         it 'allows the caller to specify a custom timeout' do
-          loop_body = described_class.new(selector: selector, clock: clock, tick_resolution: 99)
+          loop_body = described_class.new(unblocker, selector: selector, clock: clock, tick_resolution: 99)
           selector.should_receive(:select).with(anything, anything, anything, 99).and_return([[], [], []])
           loop_body.tick
         end


### PR DESCRIPTION
`Future#value` has always been the odd one out in the Future API. It's the only blocking method, and it feels like having it easily accessible makes it too easy to write bad code. I've seen people call `#value` inside of future callbacks a few times too often now.