### PR TITLE
Add ByteBuffer#getbyte

### DIFF
--- a/lib/ione/byte_buffer.rb
+++ b/lib/ione/byte_buffer.rb
@@ -174,6 +174,18 @@ module Ione
       b
     end
 
+    # Return the nt:h byte of the buffer, without removing it, and decode it as a signed or unsigned integer.
+    #
+    # @param [Integer] the zero-based positive position of the byte to read
+    # @return [Integer, nil] the integer interpretation of the byte at the specified position, or nil when beyond buffer size.
+    def getbyte(index, signed=false)
+      if @offset+index >= @read_buffer.bytesize
+        swap_buffers
+      end
+      b = @read_buffer.getbyte(@offset+index)
+      (signed && b >= 0x80) ? b - 0x100 : b
+    end
+
     def index(substring, start_index=0)
       if @offset >= @read_buffer.bytesize
         swap_buffers

--- a/spec/ione/byte_buffer_spec.rb
+++ b/spec/ione/byte_buffer_spec.rb
@@ -332,6 +332,37 @@ module Ione
       end
     end
 
+    describe '#getbyte' do
+      it 'returns the nth byte interpreted as an int' do
+        buffer.append("\x80\x01")
+        expect(buffer.getbyte(0)).to eq(0x80)
+        expect(buffer.getbyte(1)).to eq(0x01)
+      end
+
+      it 'returns nil if there are no bytes' do
+        expect(buffer.getbyte(0)).to be_nil
+      end
+
+      it 'returns nil if the index goes beyond the buffer' do
+        buffer.append("\x80\x01")
+        expect(buffer.getbyte(2)).to be_nil
+      end
+
+      it 'handles interleaved writes' do
+        buffer.append("\x80\x01")
+        buffer.read_byte
+        buffer.append("\x81\x02")
+        expect(buffer.getbyte(0)).to eq(0x01)
+        expect(buffer.getbyte(1)).to eq(0x81)
+      end
+
+      it 'can interpret the byte as signed' do
+        buffer.append("\x80\x02")
+        expect(buffer.getbyte(0, true)).to eq(-128)
+        expect(buffer.getbyte(1, true)).to eq(2)
+      end
+    end
+
     describe '#index' do
       it 'returns the first index of the specified substring' do
         buffer.append('fizz buzz')


### PR DESCRIPTION
This enables peeking cheaply into the byte buffer, without constructing new strings or raising errors when beyond the end of the buffer.