### PR TITLE
Unblock less

### DIFF
--- a/lib/ione/byte_buffer.rb
+++ b/lib/ione/byte_buffer.rb
@@ -176,7 +176,7 @@ module Ione
 
     # Return the nt:h byte of the buffer, without removing it, and decode it as a signed or unsigned integer.
     #
-    # @param [Integer] the zero-based positive position of the byte to read
+    # @param [Integer] index the zero-based positive position of the byte to read
     # @return [Integer, nil] the integer interpretation of the byte at the specified position, or nil when beyond buffer size.
     def getbyte(index, signed=false)
       if @offset+index >= @read_buffer.bytesize

--- a/lib/ione/io/io_reactor.rb
+++ b/lib/ione/io/io_reactor.rb
@@ -406,15 +406,10 @@ module Ione
       end
 
       def read
-        @lock.lock
-        if @state != CLOSED_STATE
-          @out.read_nonblock(65536)
-          @state = BLOCKABLE_STATE
-        end
-      rescue IO::WaitReadable
-        $stderr.puts('Oh noes we got blocked while reading the unblocker')
-      ensure
-        @lock.unlock
+        @out.read_nonblock(65536)
+        @state = BLOCKABLE_STATE
+      rescue IOError
+        $stderr.puts('Oh noes we read from the unblocker after it got closed, probably')
       end
 
       def close

--- a/lib/ione/io/io_reactor.rb
+++ b/lib/ione/io/io_reactor.rb
@@ -373,7 +373,6 @@ module Ione
 
       def initialize
         @out, @in = IO.pipe
-        @lock = Mutex.new
         @state = BLOCKABLE_STATE
         @writables = [@in]
       end
@@ -413,10 +412,8 @@ module Ione
       end
 
       def close
-        @lock.synchronize do
-          return if @state == CLOSED_STATE
-          @state = CLOSED_STATE
-        end
+        return if @state == CLOSED_STATE
+        @state = CLOSED_STATE
         @in.close
         @out.close
         @in = nil

--- a/lib/ione/io/io_reactor.rb
+++ b/lib/ione/io/io_reactor.rb
@@ -395,19 +395,14 @@ module Ione
       end
 
       def unblock
-        if @state != CLOSED_STATE
-          @lock.lock
-          begin
-            if @state == BLOCKABLE_STATE
-              @in.write_nonblock(PING_BYTE)
-              @state = UNBLOCKING_STATE
-            end
-          rescue IO::WaitWritable
-            $stderr.puts('Oh noes we got blocked while writing the unblocker')
-          ensure
-            @lock.unlock
-          end
+        if @state == BLOCKABLE_STATE
+          @state = UNBLOCKING_STATE
+          @in.write_nonblock(PING_BYTE)
         end
+      rescue IO::WaitWritable
+        $stderr.puts('Oh noes we got blocked while writing the unblocker')
+      rescue IOError
+        $stderr.puts('Oh noes we wrote to the unblocker after it got closed, probably')
       end
 
       def read

--- a/spec/ione/io/io_reactor_spec.rb
+++ b/spec/ione/io/io_reactor_spec.rb
@@ -184,18 +184,17 @@ module Ione
         end
 
         it 'keeps running until stop completes' do
-          running_barrier = Queue.new
-          stop_barrier = Queue.new
+          barrier = Queue.new
           selector.handler do
-            running_barrier.push(nil)
-            stop_barrier.pop
+            barrier.pop
             [[], [], []]
           end
           reactor.start.value
           future = reactor.stop
-          running_barrier.pop
+          barrier.push(nil)
           reactor.should be_running
-          stop_barrier.push(nil) until future.completed?
+          barrier.push(nil) until future.completed?
+          reactor.should_not be_running
         end
 
         it 'unblocks the reactor' do

--- a/spec/ione/io/io_reactor_spec.rb
+++ b/spec/ione/io/io_reactor_spec.rb
@@ -712,7 +712,11 @@ module Ione
 
     describe IoLoopBody do
       let :loop_body do
-        described_class.new(selector: selector, clock: clock)
+        described_class.new(unblocker, selector: selector, clock: clock)
+      end
+
+      let :unblocker do
+        double(:unblocker, connected?: true, connecting?: false, writable?: false, closed?: false)
       end
 
       let :selector do
@@ -727,14 +731,24 @@ module Ione
         double(:socket, connected?: false, connecting?: false, writable?: false, closed?: false)
       end
 
+      before do
+        unblocker.stub(:close) { unblocker.stub(:closed?).and_return(true) }
+      end
+
       describe '#tick' do
         before do
           loop_body.add_socket(socket)
         end
 
+        it 'passes the unblocker to the selector as the first readable' do
+          socket.stub(:connected?).and_return(true)
+          selector.should_receive(:select).with([unblocker, socket], anything, anything, anything).and_return([nil, nil, nil])
+          loop_body.tick
+        end
+
         it 'passes connected sockets as readables to the selector' do
           socket.stub(:connected?).and_return(true)
-          selector.should_receive(:select).with([socket], anything, anything, anything).and_return([nil, nil, nil])
+          selector.should_receive(:select).with([unblocker, socket], anything, anything, anything).and_return([nil, nil, nil])
           loop_body.tick
         end
 
@@ -747,7 +761,7 @@ module Ione
         it 'passes writable sockets as both readable and writable to the selector' do
           socket.stub(:connected?).and_return(true)
           socket.stub(:writable?).and_return(true)
-          selector.should_receive(:select).with([socket], [socket], anything, anything).and_return([nil, nil, nil])
+          selector.should_receive(:select).with([unblocker, socket], [socket], anything, anything).and_return([nil, nil, nil])
           loop_body.tick
         end
 
@@ -760,7 +774,7 @@ module Ione
 
         it 'filters out closed sockets' do
           socket.stub(:closed?).and_return(true)
-          selector.should_receive(:select).with([], [], anything, anything).and_return([nil, nil, nil])
+          selector.should_receive(:select).with([unblocker], [], anything, anything).and_return([nil, nil, nil])
           loop_body.tick
         end
 
@@ -804,7 +818,7 @@ module Ione
         end
 
         it 'allows the caller to specify a custom timeout' do
-          loop_body = described_class.new(selector: selector, clock: clock, tick_resolution: 99)
+          loop_body = described_class.new(unblocker, selector: selector, clock: clock, tick_resolution: 99)
           selector.should_receive(:select).with(anything, anything, anything, 99).and_return([[], [], []])
           loop_body.tick
         end


### PR DESCRIPTION
This is an experiment to see if we can optimize the unblocking. We'll do no locking around the unblocking, but also try to only write once to the unblocker pipe. Worst case we write a few times, but we can (as far as we can tell) only write as many times as there are cores, because after that the threads should see the changed state. On the read side we shouldn't need any locking either since it's only the IO reactor thread that reads. Same goes for close.

There's some debug printing that we'll use while trying this out in a real system.