### PR TITLE
Adds a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/) 
+
+## [Unreleased]
+### Added
+- CHANGELOG.md


### PR DESCRIPTION
In trying to contribute to this gem, the `CONTRIBUTING.md` document says:

> make your changes in a topic branch that branches off from the right place in the history (`master` isn't necessarily always the right choice)

However, it is very difficult to know what the right branch is for potential or current contributors. A changelog helps solve this problem. It also help others who depend on this gem by providing a reference for what has changed when they contemplate upgrading upon a new release.

I used a style from [keepachangelog](http://keepachangelog.com/en/0.3.0/), which is common in some other projects.