### PR TITLE
make Scheduler use the same clock as IoReactor

### DIFF
--- a/lib/ione/io/io_reactor.rb
+++ b/lib/ione/io/io_reactor.rb
@@ -97,7 +97,7 @@ module Ione
         @error_listeners = []
         @unblocker = Unblocker.new
         @io_loop = IoLoopBody.new(@unblocker, @options)
-        @scheduler = Scheduler.new
+        @scheduler = Scheduler.new(@options)
         @lock = Mutex.new
       end
 

--- a/spec/ione/io/io_reactor_spec.rb
+++ b/spec/ione/io/io_reactor_spec.rb
@@ -581,10 +581,12 @@ module Ione
           end
 
           it 'returns a future that is resolved after the specified duration' do
+            start = Time.now
             clock.stub(:now).and_return(1)
-            f = reactor.schedule_timer(0.1)
-            clock.stub(:now).and_return(1.1)
+            f = reactor.schedule_timer(8)
+            clock.stub(:now).and_return(10.1)
             await { f.resolved? }
+            expect(Time.now - start).to be < 1
           end
         end
 


### PR DESCRIPTION
This allows one to actually pass a custom `clock` to `IoReactor.new` and have it do the right thing. Prior to this, `Scheduler` always used `Time` (which would cause problems if using Ione with things that mock time, like Timecop).

This is a big part of fixing #52.