### PR TITLE
Mark mutable strings to fix ruby 3.4 warnings

### DIFF
--- a/examples/http_client/lib/ione/http_client.rb
+++ b/examples/http_client/lib/ione/http_client.rb
@@ -50,7 +50,7 @@ module Ione
     end
 
     def send_get(path, query, headers)
-      message = 'GET '
+      message = +'GET '
       message << path
       message << '?' << query if query && !query.empty?
       message << " HTTP/1.1\r\n"
@@ -72,7 +72,7 @@ module Ione
 
     def on_message_begin
       @headers = nil
-      @body = ''
+      @body = +''
     end
 
     def on_headers_complete(headers)

--- a/examples/http_client/spec/ione/http_client_spec.rb
+++ b/examples/http_client/spec/ione/http_client_spec.rb
@@ -170,7 +170,7 @@ module HttpClientSpec
         end
       when '/fizzbuzz'
         n = request.query_string.scan(/n=(\d+)/).flatten.first.to_i
-        response.body = ''
+        response.body = +''
         response.body << 'fizz' if n % 5 == 0
         response.body << 'buzz' if n % 3 == 0
         response.body << n.to_s if response.body.empty?

--- a/lib/ione/byte_buffer.rb
+++ b/lib/ione/byte_buffer.rb
@@ -18,7 +18,7 @@ module Ione
   # @since v1.0.0
   class ByteBuffer
     def initialize(initial_bytes=nil)
-      @read_buffer = ''
+      @read_buffer = +''
       @offset = 0
       @length = 0
       if initial_bytes && !initial_bytes.empty?
@@ -26,7 +26,7 @@ module Ione
         @write_buffer.force_encoding(::Encoding::BINARY)
         @length = @write_buffer.bytesize
       else
-        @write_buffer = ''
+        @write_buffer = +''
       end
     end
 
@@ -323,12 +323,12 @@ module Ione
     def swap_buffers
       @offset -= @read_buffer.bytesize
       @read_buffer = @write_buffer
-      @write_buffer = ''
+      @write_buffer = +''
     end
 
     def merge_read_buffer
       @read_buffer = @read_buffer[@offset, @read_buffer.length - @offset] << @write_buffer
-      @write_buffer = ''
+      @write_buffer = +''
       @offset = 0
     end
   end

--- a/lib/ione/io/io_reactor.rb
+++ b/lib/ione/io/io_reactor.rb
@@ -42,7 +42,7 @@ module Ione
     #       # register a listener method for new data, this must be done in the
     #       # in the constructor, and only one listener can be registered
     #       @connection.on_data(&method(:process_data))
-    #       @buffer = ''
+    #       @buffer = +''
     #     end
     #
     #     def process_data(new_data)

--- a/spec/support/fake_server.rb
+++ b/spec/support/fake_server.rb
@@ -10,7 +10,7 @@ class FakeServer
     @connects = 0
     @disconnects = 0
     @connections = []
-    @received_bytes = ''
+    @received_bytes = +''
     @running = false
   end
 


### PR DESCRIPTION
Marking mutable strings to fix ruby 3.4 warnings.